### PR TITLE
[hotfix] Can't start NestJS production

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "nest start --watch",
     "dev:docker": "yarn start:docker && (sleep 5 && yarn dev)",
     "dev:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "test": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",


### PR DESCRIPTION
Issue
- Build path change
<img width="239" alt="image" src="https://github.com/user-attachments/assets/601c56f2-5bc5-4a81-8311-e1e359d65b2b">


Solution
- Change cmd `yarn start:prod` to point at correct path